### PR TITLE
Expand VectorDB testing

### DIFF
--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -1,0 +1,74 @@
+from pathlib import Path
+import sys
+import json
+import types
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+class DummyModel:
+    dim = 3
+
+    @classmethod
+    def from_pretrained(cls, name):
+        return cls()
+
+    def encode(self, texts):
+        arr = []
+        for t in texts:
+            h = hash(t) & 0xFFFFFFFF
+            arr.append([(h >> (i * 8)) & 0xFF for i in range(self.dim)])
+        return arr
+
+class DummyIndex:
+    def __init__(self, space="cosine", dim=3):
+        self.space = space
+        self.dim = dim
+        self.vectors = {}
+
+    def init_index(self, max_elements=10000, ef_construction=200, M=16):
+        pass
+
+    def set_ef(self, ef):
+        pass
+
+    def add_items(self, vecs, ids):
+        for vec, idx in zip(vecs, ids):
+            self.vectors[int(idx)] = vec
+
+    def knn_query(self, vecs, k=5):
+        labels = []
+        distances = []
+        for vec in vecs:
+            dists = []
+            for idx, v in self.vectors.items():
+                dist = float(sum((a - b) ** 2 for a, b in zip(vec, v)) ** 0.5)
+                dists.append((dist, idx))
+            dists.sort(key=lambda x: x[0])
+            top = dists[:k]
+            labels.append([idx for _, idx in top])
+            distances.append([dist for dist, _ in top])
+        return labels, distances
+
+    def save_index(self, path):
+        Path(path).write_text(json.dumps({str(k): v for k, v in self.vectors.items()}))
+
+    def load_index(self, path):
+        data = json.loads(Path(path).read_text())
+        self.vectors = {int(k): v for k, v in data.items()}
+
+hnswlib_stub = types.ModuleType("hnswlib")
+hnswlib_stub.Index = DummyIndex
+sys.modules.setdefault("hnswlib", hnswlib_stub)
+
+model2vec_stub = types.ModuleType("model2vec")
+model2vec_stub.StaticModel = DummyModel
+sys.modules.setdefault("model2vec", model2vec_stub)
+
+@pytest.fixture(autouse=True)
+def patch_dependencies(monkeypatch):
+    import vectordb.db as db
+    monkeypatch.setattr(db, "StaticModel", DummyModel)
+    monkeypatch.setattr(db.hnswlib, "Index", DummyIndex)
+    yield

--- a/core/tests/test_api.py
+++ b/core/tests/test_api.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from fastapi.testclient import TestClient
+
+
+def test_rest_endpoints(tmp_path, monkeypatch):
+    monkeypatch.setattr("vectordb.db.INDEX_PATH", tmp_path / "index.bin")
+    monkeypatch.setattr("vectordb.db.DATA_PATH", tmp_path / "data.json")
+
+    from vectordb import VectorDB, create_app
+    vdb = VectorDB()
+    app = create_app(vdb)
+    client = TestClient(app)
+
+    resp = client.post("/add", json={"text": "foo"})
+    assert resp.status_code == 200
+
+    resp = client.get("/search", params={"q": "foo", "k": 1})
+    assert resp.status_code == 200
+    assert resp.json()[0]["text"] == "foo"

--- a/core/tests/test_cli.py
+++ b/core/tests/test_cli.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+import sys
+from io import StringIO
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+def test_cli_add_and_query(tmp_path, monkeypatch, capsys):
+    from vectordb.cli import main
+    monkeypatch.setattr("vectordb.db.INDEX_PATH", tmp_path / "index.bin")
+    monkeypatch.setattr("vectordb.db.DATA_PATH", tmp_path / "data.json")
+
+    main(["add", "foo bar"])
+    main(["query", "foo bar"])
+    captured = capsys.readouterr()
+    assert "foo bar" in captured.out
+
+
+def test_cli_serve(tmp_path, monkeypatch):
+    monkeypatch.setattr("vectordb.db.INDEX_PATH", tmp_path / "index.bin")
+    monkeypatch.setattr("vectordb.db.DATA_PATH", tmp_path / "data.json")
+
+    called = {}
+    def fake_run(app, host="0.0.0.0", port=8000):
+        called["app"] = app
+        called["host"] = host
+        called["port"] = port
+    monkeypatch.setattr("uvicorn.run", fake_run)
+    from vectordb.cli import main
+
+    main(["serve"])
+    assert called.get("app") is not None
+    assert called["host"] == "0.0.0.0" and called["port"] == 8000

--- a/core/tests/test_db.py
+++ b/core/tests/test_db.py
@@ -4,21 +4,37 @@ import sys
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-import pytest
-from vectordb import VectorDB
-
 
 def test_add_and_search(tmp_path, monkeypatch):
+    from vectordb import VectorDB
     monkeypatch.setattr("vectordb.db.INDEX_PATH", tmp_path / "index.bin")
     monkeypatch.setattr("vectordb.db.DATA_PATH", tmp_path / "data.json")
 
     vdb = VectorDB()
-
-    sentences = [f"This is sample sentence {i}" for i in range(1000)]
+    sentences = [f"This is sample sentence {i}" for i in range(20)]
     vdb.add_texts(sentences)
 
-    query = sentences[42]
+    query = sentences[5]
     results = vdb.search(query, k=5)
     texts = [r["text"] for r in results]
 
     assert query in texts
+
+
+def test_persistence_and_clear(tmp_path, monkeypatch):
+    idx = tmp_path / "index.bin"
+    data = tmp_path / "data.json"
+    monkeypatch.setattr("vectordb.db.INDEX_PATH", idx)
+    monkeypatch.setattr("vectordb.db.DATA_PATH", data)
+
+    from vectordb import VectorDB
+    vdb = VectorDB()
+    vdb.add_text("hello world")
+    assert vdb.search("hello world", k=1)[0]["text"] == "hello world"
+
+    vdb2 = VectorDB()
+    assert vdb2.search("hello world", k=1)[0]["text"] == "hello world"
+
+    VectorDB.clear()
+    assert not idx.exists()
+    assert not data.exists()


### PR DESCRIPTION
## Summary
- add dummy dependencies and fixtures for tests
- expand db tests to cover persistence and clearing
- add new CLI and REST API tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840a6603d088328b39fae6f770faaef