### PR TITLE
Reorganise test suite under package

### DIFF
--- a/core/vectordb/tests/api/test_api.py
+++ b/core/vectordb/tests/api/test_api.py
@@ -1,7 +1,9 @@
 from pathlib import Path
 import sys
 
-ROOT = Path(__file__).resolve().parents[1]
+# Add the repository's ``core`` directory to the Python path so ``vectordb``
+# can be imported when running the tests from any location.
+ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(ROOT))
 
 from fastapi.testclient import TestClient

--- a/core/vectordb/tests/cli/test_cli.py
+++ b/core/vectordb/tests/cli/test_cli.py
@@ -2,7 +2,8 @@ from pathlib import Path
 import sys
 from io import StringIO
 
-ROOT = Path(__file__).resolve().parents[1]
+# Allow importing the ``vectordb`` package when running tests directly.
+ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(ROOT))
 
 

--- a/core/vectordb/tests/conftest.py
+++ b/core/vectordb/tests/conftest.py
@@ -4,7 +4,8 @@ import json
 import types
 import pytest
 
-ROOT = Path(__file__).resolve().parents[1]
+# Make sure the ``core`` directory is on the import path for the tests.
+ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
 
 class DummyModel:

--- a/core/vectordb/tests/db/test_db.py
+++ b/core/vectordb/tests/db/test_db.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 import sys
 
-ROOT = Path(__file__).resolve().parents[1]
+# ``vectordb`` lives two directories above ``tests`` so ensure it is importable.
+ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(ROOT))
 
 


### PR DESCRIPTION
## Summary
- move all tests under `core/vectordb/tests`
- create separate folders for API, CLI and DB tests
- update imports in tests to locate the package

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841dfbabf588328b2fb21a78d52bbdc