### PR TITLE
Improve VectorDB configurability

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,12 @@ Run the CLI using the module entry point.  Because the package lives
 under `core`, add it to the Python path first:
 
 ```
-PYTHONPATH=core python -m vectordb [--delete] {serve,add,query} [text]
+PYTHONPATH=core python -m vectordb [--delete] [--index-path INDEX] [--data-path DATA] {serve,add,query} [text]
 ```
 
 - `--delete` removes any existing index/data before running.
+- `--index-path` path to the HNSW index file (default `index.bin`).
+- `--data-path` path to the stored texts file (default `data.json`).
 - `serve` starts the REST API (default port 8000).
 - `add` adds a single text entry.
 - `query` searches for the most similar texts to the provided query.

--- a/core/vectordb/cli/__init__.py
+++ b/core/vectordb/cli/__init__.py
@@ -1,7 +1,8 @@
 import argparse
+from pathlib import Path
 import uvicorn
 
-from ..db import VectorDB
+from ..db import VectorDB, INDEX_PATH, DATA_PATH
 from ..api import create_app
 
 
@@ -12,6 +13,18 @@ def main(argv=None):
         action="store_true",
         help="remove existing index and data before running",
     )
+    parser.add_argument(
+        "--index-path",
+        type=Path,
+        default=INDEX_PATH,
+        help="location of the HNSW index file",
+    )
+    parser.add_argument(
+        "--data-path",
+        type=Path,
+        default=DATA_PATH,
+        help="location of the stored texts",
+    )
     subparsers = parser.add_subparsers(dest="command", required=True)
     subparsers.add_parser("serve", help="start REST server")
     add = subparsers.add_parser("add", help="add text")
@@ -21,9 +34,9 @@ def main(argv=None):
     args = parser.parse_args(argv)
 
     if args.delete:
-        VectorDB.clear()
+        VectorDB.clear(index_path=args.index_path, data_path=args.data_path)
 
-    vdb = VectorDB()
+    vdb = VectorDB(index_path=args.index_path, data_path=args.data_path)
 
     if args.command == "serve":
         app = create_app(vdb)

--- a/core/vectordb/tests/api/test_api.py
+++ b/core/vectordb/tests/api/test_api.py
@@ -9,12 +9,10 @@ sys.path.insert(0, str(ROOT))
 from fastapi.testclient import TestClient
 
 
-def test_rest_endpoints(tmp_path, monkeypatch):
-    monkeypatch.setattr("vectordb.db.INDEX_PATH", tmp_path / "index.bin")
-    monkeypatch.setattr("vectordb.db.DATA_PATH", tmp_path / "data.json")
-
+def test_rest_endpoints(tmp_path):
     from vectordb import VectorDB, create_app
-    vdb = VectorDB()
+
+    vdb = VectorDB(index_path=tmp_path / "index.bin", data_path=tmp_path / "data.json")
     app = create_app(vdb)
     client = TestClient(app)
 

--- a/core/vectordb/tests/cli/test_cli.py
+++ b/core/vectordb/tests/cli/test_cli.py
@@ -1,27 +1,29 @@
 from pathlib import Path
 import sys
-from io import StringIO
+from io import StringIO  # noqa: F401 - imported for compatibility
 
 # Allow importing the ``vectordb`` package when running tests directly.
 ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(ROOT))
 
 
-def test_cli_add_and_query(tmp_path, monkeypatch, capsys):
+def test_cli_add_and_query(tmp_path, capsys):
     from vectordb.cli import main
-    monkeypatch.setattr("vectordb.db.INDEX_PATH", tmp_path / "index.bin")
-    monkeypatch.setattr("vectordb.db.DATA_PATH", tmp_path / "data.json")
 
-    main(["add", "foo bar"])
-    main(["query", "foo bar"])
+    args = [
+        "--index-path",
+        str(tmp_path / "index.bin"),
+        "--data-path",
+        str(tmp_path / "data.json"),
+    ]
+
+    main(args + ["add", "foo bar"])
+    main(args + ["query", "foo bar"])
     captured = capsys.readouterr()
     assert "foo bar" in captured.out
 
 
 def test_cli_serve(tmp_path, monkeypatch):
-    monkeypatch.setattr("vectordb.db.INDEX_PATH", tmp_path / "index.bin")
-    monkeypatch.setattr("vectordb.db.DATA_PATH", tmp_path / "data.json")
-
     called = {}
     def fake_run(app, host="0.0.0.0", port=8000):
         called["app"] = app
@@ -30,6 +32,13 @@ def test_cli_serve(tmp_path, monkeypatch):
     monkeypatch.setattr("uvicorn.run", fake_run)
     from vectordb.cli import main
 
-    main(["serve"])
+    args = [
+        "--index-path",
+        str(tmp_path / "index.bin"),
+        "--data-path",
+        str(tmp_path / "data.json"),
+    ]
+
+    main(args + ["serve"])
     assert called.get("app") is not None
     assert called["host"] == "0.0.0.0" and called["port"] == 8000

--- a/core/vectordb/tests/db/test_db.py
+++ b/core/vectordb/tests/db/test_db.py
@@ -6,12 +6,12 @@ ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(ROOT))
 
 
-def test_add_and_search(tmp_path, monkeypatch):
+def test_add_and_search(tmp_path):
     from vectordb import VectorDB
-    monkeypatch.setattr("vectordb.db.INDEX_PATH", tmp_path / "index.bin")
-    monkeypatch.setattr("vectordb.db.DATA_PATH", tmp_path / "data.json")
 
-    vdb = VectorDB()
+    idx = tmp_path / "index.bin"
+    data = tmp_path / "data.json"
+    vdb = VectorDB(index_path=idx, data_path=data)
     sentences = [f"This is sample sentence {i}" for i in range(20)]
     vdb.add_texts(sentences)
 
@@ -22,20 +22,18 @@ def test_add_and_search(tmp_path, monkeypatch):
     assert query in texts
 
 
-def test_persistence_and_clear(tmp_path, monkeypatch):
+def test_persistence_and_clear(tmp_path):
     idx = tmp_path / "index.bin"
     data = tmp_path / "data.json"
-    monkeypatch.setattr("vectordb.db.INDEX_PATH", idx)
-    monkeypatch.setattr("vectordb.db.DATA_PATH", data)
 
     from vectordb import VectorDB
-    vdb = VectorDB()
+    vdb = VectorDB(index_path=idx, data_path=data)
     vdb.add_text("hello world")
     assert vdb.search("hello world", k=1)[0]["text"] == "hello world"
 
-    vdb2 = VectorDB()
+    vdb2 = VectorDB(index_path=idx, data_path=data)
     assert vdb2.search("hello world", k=1)[0]["text"] == "hello world"
 
-    VectorDB.clear()
+    VectorDB.clear(index_path=idx, data_path=data)
     assert not idx.exists()
     assert not data.exists()


### PR DESCRIPTION
## Summary
- allow configuring index and data file paths when creating `VectorDB`
- expose `--index-path` and `--data-path` flags in CLI
- document the new CLI options in the README
- update tests to use the configurable paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e0bfd2dc8328827c26e7bd5fbc7a