### PR TITLE
Improve CLI configurability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ PYTHONPATH=core python -m vectordb [--delete] [--index-path INDEX] [--data-path 
 - `--delete` removes any existing index/data before running.
 - `--index-path` path to the HNSW index file (default `index.bin`).
 - `--data-path` path to the stored texts file (default `data.json`).
-- `serve` starts the REST API (default port 8000).
+- `serve` starts the REST API (use `--host` and `--port` to configure it).
+- `--host` address for the REST API when serving (default `0.0.0.0`).
+- `--port` port number for the REST API when serving (default `8000`).
 - `add` adds a single text entry.
 - `query` searches for the most similar texts to the provided query.
 

--- a/core/vectordb/cli/__init__.py
+++ b/core/vectordb/cli/__init__.py
@@ -26,7 +26,11 @@ def main(argv=None):
         help="location of the stored texts",
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
-    subparsers.add_parser("serve", help="start REST server")
+    serve = subparsers.add_parser("serve", help="start REST server")
+    serve.add_argument("--host", default="0.0.0.0", help="host for REST server")
+    serve.add_argument(
+        "--port", type=int, default=8000, help="port for REST server"
+    )
     add = subparsers.add_parser("add", help="add text")
     add.add_argument("text", help="text to add")
     query = subparsers.add_parser("query", help="query text")
@@ -40,7 +44,7 @@ def main(argv=None):
 
     if args.command == "serve":
         app = create_app(vdb)
-        uvicorn.run(app, host="0.0.0.0", port=8000)
+        uvicorn.run(app, host=args.host, port=args.port)
     elif args.command == "add":
         vdb.add_text(args.text)
     elif args.command == "query":

--- a/core/vectordb/tests/cli/test_cli.py
+++ b/core/vectordb/tests/cli/test_cli.py
@@ -39,6 +39,6 @@ def test_cli_serve(tmp_path, monkeypatch):
         str(tmp_path / "data.json"),
     ]
 
-    main(args + ["serve"])
+    main(args + ["serve", "--host", "127.0.0.1", "--port", "1234"])
     assert called.get("app") is not None
-    assert called["host"] == "0.0.0.0" and called["port"] == 8000
+    assert called["host"] == "127.0.0.1" and called["port"] == 1234

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 model2vec
 hnswlib
+httpx<0.24


### PR DESCRIPTION
## Summary
- allow `serve` command to customize host and port
- update docs and tests for new CLI options
- add `.gitignore` for Python build artifacts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841e2197fc883288f81ca1030bd93fb