### PR TITLE
Improve API key configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ python -m vectordb [--delete] [--index-path INDEX] [--data-path DATA] {serve,add
 - `--log-level` set the logging level for CLI operations.
 - `serve` starts the REST API (use `--host` and `--port` to configure it).
 - `--api-key` require this key in the `X-API-Key` header when serving.
+ - `VECTORDB_API_KEY` environment variable can also supply the API key (also
+   exposed as the constant `vectordb.API_KEY_ENV_VAR`).
 - `--host` address for the REST API when serving (default `0.0.0.0`).
 - `--port` port number for the REST API when serving (default `8000`).
 - `add` adds a single text entry.
@@ -84,8 +86,10 @@ Both endpoints validate input:
 - Text must be non-empty.
 - `k` must be at least 1 and not exceed the number of stored texts.
 
-If the server was started with `--api-key`, each request must include the same
-value in the `X-API-Key` header or a `401` error will be returned.
+If the server was started with an API key (via `--api-key` or the
+`VECTORDB_API_KEY` environment variable), each request must include the same
+value in the `X-API-Key` header or a `401` error will be returned. The
+environment variable name is also exported as `vectordb.API_KEY_ENV_VAR`.
 
 ## Example
 

--- a/core/vectordb/__init__.py
+++ b/core/vectordb/__init__.py
@@ -1,6 +1,15 @@
 """Simple in-memory vector database package."""
 
-from .db import VectorDB, INDEX_PATH, DATA_PATH, MODEL_NAME
+from .db import DATA_PATH, INDEX_PATH, MODEL_NAME, VectorDB
 from .api import create_app
 
-__all__ = ["VectorDB", "create_app", "INDEX_PATH", "DATA_PATH", "MODEL_NAME"]
+API_KEY_ENV_VAR = "VECTORDB_API_KEY"
+
+__all__ = [
+    "VectorDB",
+    "create_app",
+    "INDEX_PATH",
+    "DATA_PATH",
+    "MODEL_NAME",
+    "API_KEY_ENV_VAR",
+]

--- a/core/vectordb/api/__init__.py
+++ b/core/vectordb/api/__init__.py
@@ -1,4 +1,5 @@
 from fastapi import Depends, FastAPI, Header, HTTPException, Query
+import hmac
 from pydantic import BaseModel, constr
 
 from ..db import VectorDB
@@ -18,7 +19,7 @@ def create_app(vdb: VectorDB, api_key: str | None = None) -> FastAPI:
     app = FastAPI()
 
     def check_key(x_api_key: str | None = Header(None)) -> None:
-        if api_key and x_api_key != api_key:
+        if api_key and not (x_api_key and hmac.compare_digest(x_api_key, api_key)):
             raise HTTPException(status_code=401, detail="invalid API key")
 
     class Item(BaseModel):

--- a/core/vectordb/cli/__init__.py
+++ b/core/vectordb/cli/__init__.py
@@ -1,7 +1,10 @@
 import argparse
 from pathlib import Path
 import logging
+import os
 import uvicorn
+
+from .. import API_KEY_ENV_VAR
 
 from ..db import VectorDB, INDEX_PATH, DATA_PATH, MODEL_NAME
 from ..api import create_app
@@ -74,7 +77,10 @@ def main(argv: list[str] | None = None) -> None:
     )
     serve.add_argument(
         "--api-key",
-        help="require this API key for REST requests",
+        help=(
+            "require this API key for REST requests "
+            f"(or set {API_KEY_ENV_VAR} env var)"
+        ),
     )
     add = subparsers.add_parser("add", help="add text")
     add.add_argument("text", help="text to add")
@@ -105,7 +111,8 @@ def main(argv: list[str] | None = None) -> None:
     )
 
     if args.command == "serve":
-        app = create_app(vdb, api_key=args.api_key)
+        api_key = args.api_key or os.getenv(API_KEY_ENV_VAR)
+        app = create_app(vdb, api_key=api_key)
         uvicorn.run(app, host=args.host, port=args.port)
     elif args.command == "add":
         vdb.add_text(args.text)

--- a/core/vectordb/tests/api/test_api.py
+++ b/core/vectordb/tests/api/test_api.py
@@ -53,3 +53,14 @@ def test_api_key_required(tmp_path):
 
     resp = client.post("/add", json={"text": "foo"}, headers={"X-API-Key": "secret"})
     assert resp.status_code == 200
+
+
+def test_api_key_invalid(tmp_path):
+    from vectordb import VectorDB, create_app
+
+    vdb = VectorDB(index_path=tmp_path / "index.bin", data_path=tmp_path / "data.json")
+    app = create_app(vdb, api_key="secret")
+    client = TestClient(app)
+
+    resp = client.post("/add", json={"text": "foo"}, headers={"X-API-Key": "wrong"})
+    assert resp.status_code == 401

--- a/core/vectordb/tests/cli/test_cli.py
+++ b/core/vectordb/tests/cli/test_cli.py
@@ -68,6 +68,32 @@ def test_cli_serve_api_key(tmp_path, monkeypatch):
     assert captured["api_key"] == "secret"
 
 
+def test_cli_serve_api_key_env(tmp_path, monkeypatch):
+    captured = {}
+
+    def fake_create_app(vdb, api_key=None):
+        captured["api_key"] = api_key
+        return "app"
+
+    from vectordb import API_KEY_ENV_VAR
+
+    monkeypatch.setenv(API_KEY_ENV_VAR, "secret")
+    monkeypatch.setattr("vectordb.cli.create_app", fake_create_app)
+    monkeypatch.setattr("uvicorn.run", lambda app, host="0", port=0: None)
+    from vectordb.cli import main
+
+    args = [
+        "--index-path",
+        str(tmp_path / "index.bin"),
+        "--data-path",
+        str(tmp_path / "data.json"),
+    ]
+
+    main(args + ["serve"])
+
+    assert captured["api_key"] == "secret"
+
+
 def test_cli_custom_params(tmp_path, monkeypatch):
     captured = {}
 


### PR DESCRIPTION
## Summary
- allow supplying API key via `VECTORDB_API_KEY` environment variable
- document environment variable usage
- test CLI environment variable behaviour
- secure API key check with `hmac.compare_digest`
- centralize API key env var constant

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684208ed8aac8328b74f85a8b28ec668