### PR TITLE
Add clear CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ like any other Python package.
 Run the CLI using the installed entry point:
 
 ```
-vectordb [--delete] [--index-path INDEX] [--data-path DATA] {serve,add,query} [text]
+vectordb [--delete] [--index-path INDEX] [--data-path DATA] {serve,add,query,clear} [text]
 ```
 
 You can also invoke it as a module:
 
 ```
-python -m vectordb [--delete] [--index-path INDEX] [--data-path DATA] {serve,add,query} [text]
+python -m vectordb [--delete] [--index-path INDEX] [--data-path DATA] {serve,add,query,clear} [text]
 ```
 
 - `--delete` removes any existing index/data before running.
@@ -66,6 +66,7 @@ python -m vectordb [--delete] [--index-path INDEX] [--data-path DATA] {serve,add
 - `--port` port number for the REST API when serving (default `8000`).
 - `add` adds a single text entry.
 - `query` searches for the most similar texts to the provided query.
+- `clear` removes any stored index and texts then exits.
 
 Example:
 

--- a/core/vectordb/cli/__init__.py
+++ b/core/vectordb/cli/__init__.py
@@ -1,3 +1,5 @@
+"""Command line interface for :mod:`vectordb`."""
+
 import argparse
 from pathlib import Path
 import logging
@@ -11,6 +13,8 @@ from ..api import create_app
 
 
 def main(argv: list[str] | None = None) -> None:
+    """Run the ``vectordb`` command line interface."""
+
     parser = argparse.ArgumentParser(description="Vector DB CLI")
     parser.add_argument(
         "--delete",
@@ -70,11 +74,10 @@ def main(argv: list[str] | None = None) -> None:
         help="logging level (e.g. INFO, DEBUG)",
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("clear", help="delete stored index and texts and exit")
     serve = subparsers.add_parser("serve", help="start REST server")
     serve.add_argument("--host", default="0.0.0.0", help="host for REST server")
-    serve.add_argument(
-        "--port", type=int, default=8000, help="port for REST server"
-    )
+    serve.add_argument("--port", type=int, default=8000, help="port for REST server")
     serve.add_argument(
         "--api-key",
         help=(
@@ -95,6 +98,10 @@ def main(argv: list[str] | None = None) -> None:
     args = parser.parse_args(argv)
 
     logging.basicConfig(level=getattr(logging, args.log_level.upper()))
+
+    if args.command == "clear":
+        VectorDB.clear(index_path=args.index_path, data_path=args.data_path)
+        return
 
     if args.delete:
         VectorDB.clear(index_path=args.index_path, data_path=args.data_path)

--- a/core/vectordb/tests/cli/test_cli.py
+++ b/core/vectordb/tests/cli/test_cli.py
@@ -26,10 +26,12 @@ def test_cli_add_and_query(tmp_path, capsys):
 
 def test_cli_serve(tmp_path, monkeypatch):
     called = {}
+
     def fake_run(app, host="0.0.0.0", port=8000):
         called["app"] = app
         called["host"] = host
         called["port"] = port
+
     monkeypatch.setattr("uvicorn.run", fake_run)
     from vectordb.cli import main
 
@@ -152,16 +154,18 @@ def test_cli_log_level(tmp_path, monkeypatch):
 
     from vectordb.cli import main
 
-    main([
-        "--index-path",
-        str(tmp_path / "index.bin"),
-        "--data-path",
-        str(tmp_path / "data.json"),
-        "--log-level",
-        "DEBUG",
-        "add",
-        "foo",
-    ])
+    main(
+        [
+            "--index-path",
+            str(tmp_path / "index.bin"),
+            "--data-path",
+            str(tmp_path / "data.json"),
+            "--log-level",
+            "DEBUG",
+            "add",
+            "foo",
+        ]
+    )
 
     assert levels["level"] == logging.DEBUG
 
@@ -180,15 +184,41 @@ def test_cli_query_k_option(tmp_path, monkeypatch):
     monkeypatch.setattr("vectordb.cli.VectorDB", FakeVectorDB)
     from vectordb.cli import main
 
-    main([
-        "--index-path",
-        str(tmp_path / "index.bin"),
-        "--data-path",
-        str(tmp_path / "data.json"),
-        "query",
-        "foo",
-        "--k",
-        "3",
-    ])
+    main(
+        [
+            "--index-path",
+            str(tmp_path / "index.bin"),
+            "--data-path",
+            str(tmp_path / "data.json"),
+            "query",
+            "foo",
+            "--k",
+            "3",
+        ]
+    )
 
     assert captured["k"] == 3
+
+
+def test_cli_clear_command(tmp_path, monkeypatch):
+    called = {}
+
+    def fake_clear(index_path, data_path):
+        called["index"] = index_path
+        called["data"] = data_path
+
+    monkeypatch.setattr("vectordb.cli.VectorDB.clear", staticmethod(fake_clear))
+    from vectordb.cli import main
+
+    main(
+        [
+            "--index-path",
+            str(tmp_path / "index.bin"),
+            "--data-path",
+            str(tmp_path / "data.json"),
+            "clear",
+        ]
+    )
+
+    assert called["index"] == tmp_path / "index.bin"
+    assert called["data"] == tmp_path / "data.json"


### PR DESCRIPTION
## Summary
- improve usability and manageability by adding a `clear` subcommand
- document new command in README
- test CLI `clear` behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842127ebf608328a31726bc3cc334a7