### PR TITLE
Add robust env var parsing for serve options

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ docker run -p 8080:8080 -e VECTORDB_HOST=0.0.0.0 -e VECTORDB_PORT=8080 vectordb
 
 The container exposes port `8000` and starts the server using the default
 settings. Set `VECTORDB_HOST` and `VECTORDB_PORT` to change where the server
-binds, and `VECTORDB_API_KEY` to require an API key for all requests.
+binds (these variables are also respected by the CLI), and `VECTORDB_API_KEY`
+to require an API key for all requests.
 
 ## Command Line Usage
 
@@ -83,8 +84,8 @@ python -m vectordb [--delete] [--index-path INDEX] [--data-path DATA] {serve,add
 - `--api-key` require this key in the `X-API-Key` header when serving.
  - `VECTORDB_API_KEY` environment variable can also supply the API key (also
    exposed as the constant `vectordb.API_KEY_ENV_VAR`).
-- `--host` address for the REST API when serving (default `0.0.0.0`).
-- `--port` port number for the REST API when serving (default `8000`).
+- `--host` address for the REST API when serving (default `0.0.0.0`, or set `VECTORDB_HOST`, also exported as `vectordb.HOST_ENV_VAR`).
+- `--port` port number for the REST API when serving (default `8000`, or set `VECTORDB_PORT`, also exported as `vectordb.PORT_ENV_VAR`).
 - `--workers` number of worker processes for the REST API (default `1`).
 - `add` adds a single text entry.
 - `query` searches for the most similar texts to the provided query.

--- a/core/vectordb/__init__.py
+++ b/core/vectordb/__init__.py
@@ -1,9 +1,19 @@
-"""Simple in-memory vector database package."""
+"""Simple in-memory vector database package.
+
+The module exports constants for the environment variables recognised by the
+command line interface:
+
+``HOST_ENV_VAR`` and ``PORT_ENV_VAR`` specify where the REST API binds when
+running ``vectordb serve``. ``API_KEY_ENV_VAR`` defines the variable used to
+configure an optional API key.
+"""
 
 from .db import DATA_PATH, INDEX_PATH, MODEL_NAME, VectorDB
 from .api import create_app
 
 API_KEY_ENV_VAR = "VECTORDB_API_KEY"
+HOST_ENV_VAR = "VECTORDB_HOST"
+PORT_ENV_VAR = "VECTORDB_PORT"
 
 __version__ = "0.1.0"
 
@@ -14,5 +24,7 @@ __all__ = [
     "DATA_PATH",
     "MODEL_NAME",
     "API_KEY_ENV_VAR",
+    "HOST_ENV_VAR",
+    "PORT_ENV_VAR",
     "__version__",
 ]

--- a/core/vectordb/cli/__init__.py
+++ b/core/vectordb/cli/__init__.py
@@ -6,7 +6,7 @@ import logging
 import os
 import uvicorn
 
-from .. import API_KEY_ENV_VAR, __version__
+from .. import API_KEY_ENV_VAR, HOST_ENV_VAR, PORT_ENV_VAR, __version__
 
 from ..db import VectorDB, INDEX_PATH, DATA_PATH, MODEL_NAME
 from ..api import create_app
@@ -88,8 +88,23 @@ def main(argv: list[str] | None = None) -> None:
     subparsers = parser.add_subparsers(dest="command", required=True)
     subparsers.add_parser("clear", help="delete stored index and texts and exit")
     serve = subparsers.add_parser("serve", help="start REST server")
-    serve.add_argument("--host", default="0.0.0.0", help="host for REST server")
-    serve.add_argument("--port", type=int, default=8000, help="port for REST server")
+    host_default = os.getenv(HOST_ENV_VAR, "0.0.0.0")
+    port_env = os.getenv(PORT_ENV_VAR)
+    try:
+        port_default = int(port_env) if port_env is not None else 8000
+    except ValueError:
+        port_default = 8000
+    serve.add_argument(
+        "--host",
+        default=host_default,
+        help=f"host for REST server (or set {HOST_ENV_VAR})",
+    )
+    serve.add_argument(
+        "--port",
+        type=int,
+        default=port_default,
+        help=f"port for REST server (or set {PORT_ENV_VAR})",
+    )
     serve.add_argument(
         "--workers",
         type=int,

--- a/core/vectordb/tests/cli/test_cli.py
+++ b/core/vectordb/tests/cli/test_cli.py
@@ -120,6 +120,57 @@ def test_cli_serve_api_key_env(tmp_path, monkeypatch):
     assert captured["api_key"] == "secret"
 
 
+def test_cli_serve_host_port_env(tmp_path, monkeypatch):
+    captured = {}
+
+    def fake_run(app, host="0", port=0, log_level="info", workers=1):
+        captured["host"] = host
+        captured["port"] = port
+
+    from vectordb import HOST_ENV_VAR, PORT_ENV_VAR
+
+    monkeypatch.setenv(HOST_ENV_VAR, "1.2.3.4")
+    monkeypatch.setenv(PORT_ENV_VAR, "1234")
+    monkeypatch.setattr("uvicorn.run", fake_run)
+    from vectordb.cli import main
+
+    args = [
+        "--index-path",
+        str(tmp_path / "index.bin"),
+        "--data-path",
+        str(tmp_path / "data.json"),
+    ]
+
+    main(args + ["serve"])
+
+    assert captured["host"] == "1.2.3.4"
+    assert captured["port"] == 1234
+
+
+def test_cli_serve_invalid_port_env(tmp_path, monkeypatch):
+    captured = {}
+
+    def fake_run(app, host="0", port=0, log_level="info", workers=1):
+        captured["port"] = port
+
+    from vectordb import PORT_ENV_VAR
+
+    monkeypatch.setenv(PORT_ENV_VAR, "notanint")
+    monkeypatch.setattr("uvicorn.run", fake_run)
+    from vectordb.cli import main
+
+    args = [
+        "--index-path",
+        str(tmp_path / "index.bin"),
+        "--data-path",
+        str(tmp_path / "data.json"),
+    ]
+
+    main(args + ["serve"])
+
+    assert captured["port"] == 8000
+
+
 def test_cli_custom_params(tmp_path, monkeypatch):
     captured = {}
 


### PR DESCRIPTION
## Summary
- ignore invalid `VECTORDB_PORT` values when serving
- show environment variable constants in the docs
- document exported constants in package

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68457c1ed93083289ebdcb35c07af5e6