### PR TITLE
Add changelog and log-level env var

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install fastapi uvicorn httpx pytest
+          pip install -r requirements.txt
       - name: Run tests
         run: |
           PYTHONPATH=core pytest -q

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+- _Nothing yet_
+
+## [0.1.0] - 2024-06-01
+- Initial release of the vector database with REST API and CLI

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,8 @@ Improve maintainability by adding type hints to VectorDB
 - Follow [PEP 8](https://peps.python.org/pep-0008/) conventions.
 - Keep functions small and focused.
 - Add docstrings for public functions and classes.
+- Code is formatted with **Black** (line length 88) and linted with **Ruff**.
+  Configuration for both tools resides in `pyproject.toml`.
 
 ## Pull Requests
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,13 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY core ./core
 COPY pyproject.toml README.md ./
 
+RUN useradd -m appuser && chown -R appuser /app
+
 ENV VECTORDB_HOST=0.0.0.0
 ENV VECTORDB_PORT=8000
 
 EXPOSE 8000
+
+USER appuser
 
 CMD ["sh", "-c", "vectordb serve --host $VECTORDB_HOST --port $VECTORDB_PORT"]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ The project is organised using a *core layout*.  All package code lives
 in `core/vectordb` which contains the database logic, REST API and a
 small CLI entry point.
 
+For a history of changes, see [CHANGELOG.md](CHANGELOG.md).
+
 ## Features
 
 - Add text entries and persist them on disk.
@@ -170,6 +172,7 @@ defaults are exposed via constants in `vectordb.__init__`.
 | `VECTORDB_INDEX_PATH` | Location of the HNSW index file | `vectordb.INDEX_PATH_ENV_VAR` |
 | `VECTORDB_DATA_PATH` | Location of stored texts | `vectordb.DATA_PATH_ENV_VAR` |
 | `VECTORDB_MODEL_NAME` | Default embedding model name | `vectordb.MODEL_NAME_ENV_VAR` |
+| `VECTORDB_LOG_LEVEL` | Default log level for the CLI | `vectordb.LOG_LEVEL_ENV_VAR` |
 
 Example `.env` snippet:
 

--- a/core/vectordb/__init__.py
+++ b/core/vectordb/__init__.py
@@ -7,8 +7,8 @@ command line interface:
 running ``vectordb serve``. ``API_KEY_ENV_VAR`` defines the variable used to
 configure an optional API key. ``INDEX_PATH_ENV_VAR`` and ``DATA_PATH_ENV_VAR``
 can override the default locations of the index and stored texts. ``MODEL_NAME_ENV_VAR``
-allows overriding the default embedding model used by :class:`VectorDB` and the
-command line interface.
+and ``LOG_LEVEL_ENV_VAR`` allow overriding the default embedding model and log
+level used by :class:`VectorDB` and the command line interface.
 """
 
 from .db import DATA_PATH, INDEX_PATH, MODEL_NAME, VectorDB
@@ -20,6 +20,7 @@ PORT_ENV_VAR = "VECTORDB_PORT"
 INDEX_PATH_ENV_VAR = "VECTORDB_INDEX_PATH"
 DATA_PATH_ENV_VAR = "VECTORDB_DATA_PATH"
 MODEL_NAME_ENV_VAR = "VECTORDB_MODEL_NAME"
+LOG_LEVEL_ENV_VAR = "VECTORDB_LOG_LEVEL"
 
 __version__ = "0.1.0"
 
@@ -35,5 +36,6 @@ __all__ = [
     "INDEX_PATH_ENV_VAR",
     "DATA_PATH_ENV_VAR",
     "MODEL_NAME_ENV_VAR",
+    "LOG_LEVEL_ENV_VAR",
     "__version__",
 ]

--- a/core/vectordb/cli/__init__.py
+++ b/core/vectordb/cli/__init__.py
@@ -91,10 +91,12 @@ def main(argv: list[str] | None = None) -> None:
         default=1000,
         help="maximum length of text entries",
     )
+    from .. import LOG_LEVEL_ENV_VAR
+
     parser.add_argument(
         "--log-level",
-        default="WARNING",
-        help="logging level (e.g. INFO, DEBUG)",
+        default=os.getenv(LOG_LEVEL_ENV_VAR, "WARNING"),
+        help=f"logging level (e.g. INFO, DEBUG) (or set {LOG_LEVEL_ENV_VAR})",
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
     subparsers.add_parser("clear", help="delete stored index and texts and exit")

--- a/core/vectordb/tests/cli/test_cli.py
+++ b/core/vectordb/tests/cli/test_cli.py
@@ -296,6 +296,37 @@ def test_cli_log_level(tmp_path, monkeypatch):
     assert levels["level"] == logging.DEBUG
 
 
+def test_cli_log_level_env(tmp_path, monkeypatch):
+    levels = {}
+
+    monkeypatch.setattr(
+        "vectordb.cli.VectorDB",
+        lambda **kwargs: type("D", (), {"add_text": lambda self, text: None})(),
+    )
+
+    def fake_basic(level):
+        levels["level"] = level
+
+    monkeypatch.setattr("logging.basicConfig", fake_basic)
+
+    from vectordb import LOG_LEVEL_ENV_VAR
+    monkeypatch.setenv(LOG_LEVEL_ENV_VAR, "INFO")
+    from vectordb.cli import main
+
+    main(
+        [
+            "--index-path",
+            str(tmp_path / "index.bin"),
+            "--data-path",
+            str(tmp_path / "data.json"),
+            "add",
+            "foo",
+        ]
+    )
+
+    assert levels["level"] == logging.INFO
+
+
 def test_cli_query_k_option(tmp_path, monkeypatch):
     captured = {}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,11 @@ where = ["core"]
 
 [tool.setuptools.package-data]
 vectordb = ["py.typed"]
+
+[tool.black]
+line-length = 88
+target-version = ["py310", "py311", "py312"]
+
+[tool.ruff]
+line-length = 88
+target-version = "py310"


### PR DESCRIPTION
## Summary
- add CHANGELOG with current history
- reference the changelog in README
- run `pip install -r requirements.txt` in CI workflow
- configure Black and Ruff in pyproject
- mention style tools in CONTRIBUTING
- run as dedicated user in Dockerfile
- allow log level override via `VECTORDB_LOG_LEVEL`
- test log level env var

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849af51ff88832882ee948b7aa91f21